### PR TITLE
비밀번호 변경 로직 이동 + 이름 조회 API 구현

### DIFF
--- a/src/main/java/com/mfc/auth/auth/application/MemberService.java
+++ b/src/main/java/com/mfc/auth/auth/application/MemberService.java
@@ -1,5 +1,8 @@
 package com.mfc.auth.auth.application;
 
+import com.mfc.auth.auth.dto.req.ModifyPasswordReqDto;
+
 public interface MemberService {
 	void resign(String uuid);
+	void modifyPassword(String uuid, ModifyPasswordReqDto dto);
 }

--- a/src/main/java/com/mfc/auth/auth/application/MemberService.java
+++ b/src/main/java/com/mfc/auth/auth/application/MemberService.java
@@ -1,8 +1,10 @@
 package com.mfc.auth.auth.application;
 
 import com.mfc.auth.auth.dto.req.ModifyPasswordReqDto;
+import com.mfc.auth.auth.dto.resp.MemberNameRespDto;
 
 public interface MemberService {
 	void resign(String uuid);
 	void modifyPassword(String uuid, ModifyPasswordReqDto dto);
+	MemberNameRespDto getName(String uuid);
 }

--- a/src/main/java/com/mfc/auth/auth/application/MemberServiceImpl.java
+++ b/src/main/java/com/mfc/auth/auth/application/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.mfc.auth.auth.domain.Member;
 import com.mfc.auth.auth.dto.kafka.DeleteProfileDto;
 import com.mfc.auth.auth.dto.req.ModifyPasswordReqDto;
+import com.mfc.auth.auth.dto.resp.MemberNameRespDto;
 import com.mfc.auth.auth.infrastructure.MemberRepository;
 import com.mfc.auth.common.exception.BaseException;
 
@@ -24,8 +25,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public void resign(String uuid) {
-		Member member = memberRepository.findByUuid(uuid)
-				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+		Member member = isExist(uuid);
 
 		memberRepository.save(Member.builder()
 				.id(member.getId())
@@ -43,8 +43,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public void modifyPassword(String uuid, ModifyPasswordReqDto dto) {
-		Member member = memberRepository.findByUuid(uuid)
-				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+		Member member = isExist(uuid);
 
 		memberRepository.save(Member.builder()
 				.id(member.getId())
@@ -55,5 +54,19 @@ public class MemberServiceImpl implements MemberService {
 				.status(member.getStatus())
 				.build()
 		);
+	}
+
+	@Override
+	public MemberNameRespDto getName(String uuid) {
+		Member member = isExist(uuid);
+
+		return MemberNameRespDto.builder()
+				.name(member.getName())
+				.build();
+	}
+
+	private Member isExist(String uuid) {
+		return memberRepository.findByUuid(uuid)
+				.orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/mfc/auth/auth/dto/req/ModifyPasswordReqDto.java
+++ b/src/main/java/com/mfc/auth/auth/dto/req/ModifyPasswordReqDto.java
@@ -1,0 +1,9 @@
+package com.mfc.auth.auth.dto.req;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class ModifyPasswordReqDto {
+	private String password;
+}

--- a/src/main/java/com/mfc/auth/auth/dto/resp/MemberNameRespDto.java
+++ b/src/main/java/com/mfc/auth/auth/dto/resp/MemberNameRespDto.java
@@ -1,0 +1,10 @@
+package com.mfc.auth.auth.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberNameRespDto {
+	private String name;
+}

--- a/src/main/java/com/mfc/auth/auth/presentation/MemberController.java
+++ b/src/main/java/com/mfc/auth/auth/presentation/MemberController.java
@@ -2,13 +2,19 @@ package com.mfc.auth.auth.presentation;
 
 import static com.mfc.auth.common.response.BaseResponseStatus.*;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mfc.auth.auth.application.MemberService;
+import com.mfc.auth.auth.dto.req.ModifyPasswordReqDto;
+import com.mfc.auth.auth.vo.req.ModifyPasswordReqVo;
 import com.mfc.auth.common.exception.BaseException;
 import com.mfc.auth.common.response.BaseResponse;
 
@@ -22,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "members", description = "회원 서비스 컨트롤러 (토큰 필요)")
 public class MemberController {
 	private final MemberService memberService;
+	private final ModelMapper modelMapper;
 
 	@PostMapping("/resign")
 	@Operation(summary = "회원 탈퇴 API", description = "유저/파트너 한 번에 탈퇴 (삭제)")
@@ -31,6 +38,20 @@ public class MemberController {
 		}
 
 		memberService.resign(uuid);
+		return new BaseResponse<>();
+	}
+
+	@PutMapping("/password")
+	@Operation(summary = "비밀번호 수정 API", description = "유저/파트너 공통 적용")
+	public BaseResponse<Void> modifyPassword(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid,
+			@RequestBody @Validated ModifyPasswordReqVo vo) {
+
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
+
+		memberService.modifyPassword(uuid, modelMapper.map(vo, ModifyPasswordReqDto.class));
 		return new BaseResponse<>();
 	}
 }

--- a/src/main/java/com/mfc/auth/auth/presentation/MemberController.java
+++ b/src/main/java/com/mfc/auth/auth/presentation/MemberController.java
@@ -5,6 +5,7 @@ import static com.mfc.auth.common.response.BaseResponseStatus.*;
 import org.modelmapper.ModelMapper;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.mfc.auth.auth.application.MemberService;
 import com.mfc.auth.auth.dto.req.ModifyPasswordReqDto;
 import com.mfc.auth.auth.vo.req.ModifyPasswordReqVo;
+import com.mfc.auth.auth.vo.resp.MemberNameRespVo;
 import com.mfc.auth.common.exception.BaseException;
 import com.mfc.auth.common.response.BaseResponse;
 
@@ -53,5 +55,13 @@ public class MemberController {
 
 		memberService.modifyPassword(uuid, modelMapper.map(vo, ModifyPasswordReqDto.class));
 		return new BaseResponse<>();
+	}
+
+	@GetMapping("/name")
+	@Operation(summary = "회원 이름 조회 API", description = "회원 이름(실명) 조회")
+	public BaseResponse<MemberNameRespVo> getName(
+			@RequestHeader(name = "UUID", defaultValue = "") String uuid) {
+		return new BaseResponse<>(modelMapper.map(
+				memberService.getName(uuid), MemberNameRespVo.class));
 	}
 }

--- a/src/main/java/com/mfc/auth/auth/vo/req/ModifyPasswordReqVo.java
+++ b/src/main/java/com/mfc/auth/auth/vo/req/ModifyPasswordReqVo.java
@@ -1,0 +1,11 @@
+package com.mfc.auth.auth.vo.req;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class ModifyPasswordReqVo {
+	@Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[~!@#$%^&*()])[A-Za-z\\d~!@#$%^&*()]{8,20}$",
+		message = "비밀번호는 영대소문자, 숫자, 특수문자를 1개 이상 포함해야 하며, 8~20자여야 합니다.")
+	private String password;
+}

--- a/src/main/java/com/mfc/auth/auth/vo/resp/MemberNameRespVo.java
+++ b/src/main/java/com/mfc/auth/auth/vo/resp/MemberNameRespVo.java
@@ -1,0 +1,9 @@
+package com.mfc.auth.auth.vo.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberNameRespVo {
+	private String name;
+}


### PR DESCRIPTION
## 📣 비밀번호 변경 로직 이동 + 이름 조회 API 구현
### 📅 2024.06.13
 
 ### 🌵Branch
`feature/refactor` → `develop`

### 📢 Description
- 비밀번호 변경 로직 이동
- 이름 조회 API 구현

### 💬Issue Number
close #7 

### 🛠️Type
- [x] 새로운 기능 추가 
- [ ] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [ ] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
